### PR TITLE
chore(public): conflict-free sanitized sync from private main

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ cd lumina-quant
 # Ensure compatible Python (project requires < 3.14)
 uv python pin 3.13
 
-# Install dependencies
-uv sync --all-extras  # or pip install ".[live,optimize,dashboard]"
+# Install dependencies (uv-only runtime)
+uv sync --all-extras
 
 # Verify install and tests
 uv run python scripts/verify_install.py

--- a/README_KR.md
+++ b/README_KR.md
@@ -86,8 +86,8 @@ cd lumina-quant
 # 프로젝트 Python 버전 고정 (< 3.14)
 uv python pin 3.13
 
-# 의존성 설치
-uv sync --all-extras  # 또는 pip install ".[live,optimize,dashboard]"
+# 의존성 설치 (uv 전용 런타임)
+uv sync --all-extras
 
 # (선택 사항) MT5 지원을 위한 설치
 uv sync --extra mt5

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,56 +1,15 @@
-# 🚀 Deployment Guide
+# 🚀 Deployment Guide (Local / UV-Only)
 
-This guide explains how to deploy **LuminaQuant** to a remote server (AWS, GCP, VPS) for 24/7 trading.
+This guide explains how to run **LuminaQuant** in the current local-first stack.
+Docker deployment is intentionally out of scope for this runtime profile.
 
-## 📦 Option 1: Docker (Recommended)
-
-Docker ensures the environment is exactly the same as development.
-
-### 1. Prerequisites
-- Docker & Docker Compose installed on the server.
-- `.env` file with API keys.
-
-### 2. Setup
-Copy the project to your server:
-```bash
-git clone https://github.com/HokyoungJung/LuminaQuant.git
-cd lumina-quant
-```
-
-Create/Edit `.env`:
-```bash
-nano .env
-# Paste your keys
-TELEGRAM_BOT_TOKEN=...
-TELEGRAM_CHAT_ID=...
-```
-
-### 3. Run
-Start in detached mode (background):
-```bash
-docker-compose up -d
-```
-
-View logs:
-```bash
-docker-compose logs -f
-```
-
-Stop:
-```bash
-docker-compose down
-```
-
----
-
-## ☁️ Option 2: Linux Service (Systemd)
-
-If you prefer running directly on the OS.
+## ☁️ Linux Service (Systemd, uv-only)
 
 ### 1. Install Dependencies
 ```bash
-apt update && apt install python3-pip
-pip install ".[live,optimize,dashboard]"
+apt update && apt install -y curl
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv sync --all-extras
 ```
 
 ### 2. Create Service File
@@ -64,7 +23,7 @@ After=network.target
 [Service]
 User=ubuntu
 WorkingDirectory=/home/ubuntu/lumina-quant
-ExecStart=/usr/bin/python3 run_live_ws.py
+ExecStart=/home/ubuntu/.local/bin/uv run python run_live_ws.py
 Restart=always
 EnvironmentFile=/home/ubuntu/lumina-quant/.env
 

--- a/docs/EXCHANGES.md
+++ b/docs/EXCHANGES.md
@@ -7,7 +7,7 @@ LuminaQuant supports multiple exchanges through a unified interface. Currently s
 LuminaQuant relies on the `ccxt` library to connect to over 100+ crypto exchanges, with first-class support for Binance.
 
 ### Prerequisites
-- Python `ccxt` package (installed via `uv sync` or `pip install ccxt`).
+- Python `ccxt` package (installed via `uv sync`).
 - A Binance Account (Real or Testnet).
 - API Key and Secret Key.
 

--- a/docs/OPTIMIZATION_REFACTOR_NOTES.md
+++ b/docs/OPTIMIZATION_REFACTOR_NOTES.md
@@ -60,7 +60,7 @@ existing behavior while reducing runtime and temporary allocations.
 
 All tests pass after refactor:
 
-- `51 passed` via `python -m pytest`
+- `51 passed` via `uv run python -m pytest`
 
 Benchmarks (median of 2 measured iterations, 1 warmup):
 

--- a/docs/RUNBOOK_1Y_1S_LOCAL.md
+++ b/docs/RUNBOOK_1Y_1S_LOCAL.md
@@ -1,0 +1,151 @@
+# 1Y+ 1s Local Runbook (8GB RAM / 8GB VRAM)
+
+This runbook is for **local-only uv runtime** and the current LuminaQuant stack:
+- market data: monthly parquet + binary WAL
+- control plane: PostgreSQL
+- compute: Polars (GPU auto fallback)
+
+---
+
+## 0) One-time setup
+
+```bash
+cd /home/hoky/Quants-agent/LuminaQuant
+uv sync --all-extras
+uv run python scripts/init_postgres_schema.py --dsn "$LQ_POSTGRES_DSN"
+```
+
+Use symbols (top10 + XAU/XAG) via env override:
+
+```bash
+export LQ__TRADING__SYMBOLS='["BTC/USDT","ETH/USDT","BNB/USDT","SOL/USDT","XRP/USDT","ADA/USDT","DOGE/USDT","TRX/USDT","LTC/USDT","LINK/USDT","XAU/USDT","XAG/USDT"]'
+```
+
+---
+
+## 1) Backfill 1-second data (1 year+)
+
+```bash
+uv run python scripts/sync_binance_ohlcv.py \
+  --symbols BTC/USDT ETH/USDT BNB/USDT SOL/USDT XRP/USDT ADA/USDT DOGE/USDT TRX/USDT LTC/USDT LINK/USDT XAU/USDT XAG/USDT \
+  --timeframe 1s \
+  --db-path data/market_parquet \
+  --exchange-id binance \
+  --market-type future \
+  --since 2025-01-01T00:00:00+00:00 \
+  --until 2025-12-31T23:59:59+00:00 \
+  --limit 1000 \
+  --max-batches 100000 \
+  --retries 3 \
+  --no-export-csv
+```
+
+Compact WAL into bounded monthly parquet files:
+
+```bash
+uv run python scripts/compact_wal_to_monthly_parquet.py \
+  --root-path data/market_parquet \
+  --exchange binance
+```
+
+---
+
+## 2) Runtime knobs for 8GB-safe runs
+
+```bash
+export LQ_GPU_MODE=auto
+export LQ_GPU_DEVICE=0
+export LQ_GPU_VERBOSE=0
+
+export LQ_SKIP_AHEAD=1
+export LQ_BT_CHUNK_DAYS=7            # tune 1..60
+export LQ_BT_CHUNK_WARMUP_BARS=0
+
+export LQ_BACKTEST_LOW_MEMORY=1
+export LQ_BACKTEST_PERSIST_OUTPUT=0
+export LQ_AUTO_COLLECT_DB=0
+```
+
+---
+
+## 3) 1Y 1s backtest (memory-profiled)
+
+```bash
+/usr/bin/time -v \
+uv run python run_backtest.py \
+  --data-source db \
+  --market-db-path data/market_parquet \
+  --market-exchange binance \
+  --base-timeframe 1s \
+  --low-memory \
+  --no-persist-output \
+  --no-auto-collect-db \
+  --run-id bt-1y-1s-$(date +%Y%m%d-%H%M%S) \
+2>&1 | tee logs/backtest_1y_1s.log
+```
+
+Extract peak RSS (KB):
+
+```bash
+grep "Maximum resident set size" logs/backtest_1y_1s.log
+```
+
+---
+
+## 4) 1Y 1s optimization (OOM-safe profile)
+
+```bash
+/usr/bin/time -v \
+uv run python optimize.py \
+  --data-source db \
+  --market-db-path data/market_parquet \
+  --market-exchange binance \
+  --base-timeframe 1s \
+  --folds 3 \
+  --n-trials 20 \
+  --max-workers 1 \
+  --oos-days 30 \
+  --no-auto-collect-db \
+  --run-id opt-1y-1s-$(date +%Y%m%d-%H%M%S) \
+2>&1 | tee logs/optimize_1y_1s.log
+```
+
+---
+
+## 5) Pass/Fail gates (local hardware)
+
+- Backtest/opt run completes with exit code 0
+- No OOM-kill (`dmesg -T | grep -i -E "killed process|out of memory"` should be empty for run window)
+- Peak RSS stays below practical limit (recommend target: **< 7.2 GiB** on 8GB host)
+- No fallback contract regressions:
+  - `uv run python scripts/audit_hardcoded_params.py` → `new=0`
+  - `uv run python scripts/check_architecture.py` passes
+
+---
+
+## 6) If memory is still too high
+
+1. Lower chunk size:
+   ```bash
+   export LQ_BT_CHUNK_DAYS=3
+   ```
+2. Keep optimization worker at 1:
+   ```bash
+   --max-workers 1
+   ```
+3. Ensure low-memory output is active:
+   ```bash
+   --low-memory --no-persist-output
+   ```
+4. Re-run WAL compaction before next run.
+
+---
+
+## 7) Streamlit GUI (monitor + launcher)
+
+```bash
+uv run python -m streamlit run dashboard.py
+```
+
+Live real mode remains gated by dashboard arming phrase: **ENABLE REAL**.
+

--- a/docs/WSL_MT5_COMMANDS.md
+++ b/docs/WSL_MT5_COMMANDS.md
@@ -65,7 +65,7 @@ Expected output:
 
 ```bash
 # Configuration and core tests
-python -m pytest tests/test_runtime_config_loader.py tests/test_mt5_exchange.py tests/test_data_sync.py
+uv run python -m pytest tests/test_runtime_config_loader.py tests/test_mt5_exchange.py tests/test_data_sync.py
 
 # Start live runner in paper mode first
 uv run python run_live.py

--- a/docs/kr/EXCHANGES.md
+++ b/docs/kr/EXCHANGES.md
@@ -7,7 +7,7 @@ LuminaQuant는 통합 인터페이스를 통해 여러 거래소를 지원합니
 LuminaQuant는 `ccxt` 라이브러리를 사용하여 바이낸스를 포함한 100개 이상의 암호화폐 거래소에 연결합니다.
 
 ### 필수 조건 (Prerequisites)
-- Python `ccxt` 패키지 (`uv sync` 또는 `pip install ccxt`로 설치).
+- Python `ccxt` 패키지 (`uv sync`로 설치).
 - 바이낸스 계정 (실계좌 또는 테스트넷).
 - API Key 및 Secret Key.
 

--- a/lumina_quant/strategy.py
+++ b/lumina_quant/strategy.py
@@ -19,3 +19,8 @@ class Strategy(ABC):
     def set_state(self, state: dict) -> None:
         """Backward-compatible default state loader."""
         _ = state
+
+    @classmethod
+    def get_param_schema(cls) -> dict:
+        """Optional hyper-parameter schema for registry-driven tuning."""
+        return {}

--- a/lumina_quant/strategy_factory/pipeline.py
+++ b/lumina_quant/strategy_factory/pipeline.py
@@ -248,7 +248,7 @@ def render_shortlist_markdown(shortlist_payload: dict[str, Any]) -> str:
     lines.append("")
     lines.append("```bash")
     lines.append(
-        "python scripts/run_strategy_factory_pipeline.py --backend parquet-postgres"
+        "uv run python scripts/run_strategy_factory_pipeline.py --backend parquet-postgres"
     )
     lines.append("```")
     lines.append("")

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -11,14 +11,51 @@ from lumina_quant.backtesting.data import HistoricCSVDataHandler
 from lumina_quant.backtesting.execution_sim import SimulatedExecutionHandler
 from lumina_quant.backtesting.portfolio_backtest import Portfolio
 from lumina_quant.config import BacktestConfig, BaseConfig, LiveConfig, OptimizationConfig
-from lumina_quant.data_collector import auto_collect_market_data
 from lumina_quant.market_data import load_data_dict_from_db, normalize_timeframe_token
 from lumina_quant.parquet_market_data import (
     is_parquet_market_data_store,
     load_data_dict_from_parquet,
 )
 from lumina_quant.utils.audit_store import AuditStore
-from strategies import registry as strategy_registry
+
+try:
+    from lumina_quant.data_collector import auto_collect_market_data
+except Exception:
+    def auto_collect_market_data(**_kwargs):  # type: ignore[no-redef]
+        return []
+
+
+try:
+    from strategies import registry as strategy_registry
+except Exception:
+    class _UnavailableStrategy:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def calculate_signals(self, _event):
+            return None
+
+    class _PublicStrategyRegistryFallback:
+        DEFAULT_STRATEGY_NAME = "UnavailableStrategy"
+
+        @staticmethod
+        def get_strategy_map():
+            return {"UnavailableStrategy": _UnavailableStrategy}
+
+        @staticmethod
+        def resolve_strategy_class(_requested_name, default_name=None):
+            _ = default_name
+            return _UnavailableStrategy
+
+        @staticmethod
+        def get_default_strategy_params(_strategy_name):
+            return {}
+
+        @staticmethod
+        def resolve_strategy_params(_strategy_name, params):
+            return dict(params or {})
+
+    strategy_registry = _PublicStrategyRegistryFallback()
 
 # ==========================================
 # CONFIGURATION FROM YAML
@@ -73,6 +110,8 @@ if os.path.exists(param_path):
 else:
     print(f"[INFO] Optimized params not found at {param_path}. Using Defaults.")
 
+STRATEGY_PARAMS = strategy_registry.resolve_strategy_params(strategy_name, STRATEGY_PARAMS)
+
 
 # 3. Data Settings
 CSV_DIR = "data"
@@ -113,6 +152,23 @@ AUTO_COLLECT_DB = str(os.getenv("LQ_AUTO_COLLECT_DB", "0")).strip().lower() not 
     "no",
     "off",
 }
+
+
+def _env_bool(name, default=False):
+    raw = os.getenv(name)
+    if raw is None:
+        return bool(default)
+    return str(raw).strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _env_optional_bool(name):
+    raw = os.getenv(name)
+    if raw is None:
+        return None
+    token = str(raw).strip()
+    if not token:
+        return None
+    return token.lower() not in {"0", "false", "no", "off"}
 
 
 def _env_int(name, default):
@@ -243,6 +299,13 @@ def _safe_float(value):
         return None
 
 
+def _safe_float_or(value, default):
+    parsed = _safe_float(value)
+    if parsed is None:
+        return float(default)
+    return float(parsed)
+
+
 def _persist_backtest_audit_rows(audit_store, run_id, backtest):
     equity_rows = 0
     fill_rows = 0
@@ -304,6 +367,57 @@ def _persist_backtest_audit_rows(audit_store, run_id, backtest):
     return {"equity_rows": equity_rows, "fill_rows": fill_rows}
 
 
+def _resolve_execution_profile(*, low_memory=None, persist_output=None):
+    resolved_low_memory = (
+        _env_bool("LQ_BACKTEST_LOW_MEMORY", False) if low_memory is None else bool(low_memory)
+    )
+    resolved_persist_output = persist_output
+    if resolved_persist_output is None:
+        resolved_persist_output = _env_optional_bool("LQ_BACKTEST_PERSIST_OUTPUT")
+    if resolved_persist_output is None:
+        resolved_persist_output = (
+            False
+            if resolved_low_memory
+            else bool(getattr(BacktestConfig, "PERSIST_OUTPUT", True))
+        )
+    return {
+        "low_memory": bool(resolved_low_memory),
+        "record_history": not bool(resolved_low_memory),
+        "track_metrics": True,
+        "record_trades": not bool(resolved_low_memory),
+        "persist_output": bool(resolved_persist_output),
+    }
+
+
+def _print_low_memory_stats(backtest):
+    fast_stats = {}
+    try:
+        fast_stats = dict(backtest.portfolio.output_summary_stats_fast() or {})
+    except Exception as exc:
+        fast_stats = {"status": f"error: {exc}"}
+
+    final_equity = _safe_float(getattr(backtest.portfolio, "current_holdings", {}).get("total"))
+    trade_count = int(getattr(backtest.portfolio, "trade_count", 0))
+    print("[INFO] Low-memory mode enabled (history/trade logs disabled).")
+    print(
+        "[INFO] Backtest summary: "
+        f"final_equity={final_equity if final_equity is not None else 0.0:.4f}, "
+        f"trade_count={trade_count}, "
+        f"sharpe={_safe_float_or(fast_stats.get('sharpe'), 0.0):.4f}, "
+        f"cagr={_safe_float_or(fast_stats.get('cagr'), 0.0):.6f}, "
+        f"max_drawdown={_safe_float_or(fast_stats.get('max_drawdown'), 0.0):.6f}"
+    )
+    return fast_stats
+
+
+def _persist_low_memory_outputs(backtest, persist_output):
+    if not bool(persist_output):
+        return
+    backtest.portfolio.create_equity_curve_dataframe()
+    backtest.portfolio.output_trade_log(os.path.join("data", "trades.csv"))
+    backtest.portfolio.save_equity_curve(os.path.join("data", "equity.csv"))
+
+
 def run(
     data_source="auto",
     market_db_path=MARKET_DB_PATH,
@@ -311,6 +425,8 @@ def run(
     base_timeframe=BASE_TIMEFRAME,
     auto_collect_db=AUTO_COLLECT_DB,
     run_id="",
+    low_memory=None,
+    persist_output=None,
 ):
     print("------------------------------------------------")
     print(f"Running Backtest for {SYMBOL_LIST}")
@@ -321,6 +437,10 @@ def run(
     backtest_run_id = str(run_id or "").strip() or str(uuid.uuid4())
     timeframe_token = _enforce_1s_base_timeframe(str(base_timeframe))
     audit_store = AuditStore(BaseConfig.POSTGRES_DSN)
+    execution_profile = _resolve_execution_profile(
+        low_memory=low_memory,
+        persist_output=persist_output,
+    )
     audit_store.start_run(
         mode="backtest",
         metadata={
@@ -333,6 +453,7 @@ def run(
             "base_timeframe": str(timeframe_token),
             "strategy_timeframe": str(BaseConfig.TIMEFRAME),
             "auto_collect_db": bool(auto_collect_db),
+            **execution_profile,
         },
         run_id=backtest_run_id,
     )
@@ -386,12 +507,18 @@ def run(
                 data_handler_cls=HistoricCSVDataHandler,
                 execution_handler_cls=SimulatedExecutionHandler,
                 portfolio_cls=Portfolio,
-                record_history=True,
-                track_metrics=True,
-                record_trades=True,
+                record_history=bool(execution_profile["record_history"]),
+                track_metrics=bool(execution_profile["track_metrics"]),
+                record_trades=bool(execution_profile["record_trades"]),
             )
-            persist_output = bool(getattr(backtest.config, "PERSIST_OUTPUT", True))
-            backtest._output_performance(persist_output=persist_output, verbose=True)
+            if bool(execution_profile["low_memory"]):
+                _persist_low_memory_outputs(backtest, execution_profile["persist_output"])
+                _print_low_memory_stats(backtest)
+            else:
+                backtest._output_performance(
+                    persist_output=bool(execution_profile["persist_output"]),
+                    verbose=True,
+                )
         else:
             backtest = Backtest(
                 csv_dir=CSV_DIR,
@@ -404,9 +531,19 @@ def run(
                 strategy_cls=STRATEGY_CLASS,
                 strategy_params=STRATEGY_PARAMS,
                 data_dict=data_dict,
+                record_history=bool(execution_profile["record_history"]),
+                track_metrics=bool(execution_profile["track_metrics"]),
+                record_trades=bool(execution_profile["record_trades"]),
                 strategy_timeframe=str(BaseConfig.TIMEFRAME),
             )
-            backtest.simulate_trading()
+            if bool(execution_profile["low_memory"]):
+                backtest.simulate_trading(output=False)
+                _persist_low_memory_outputs(backtest, execution_profile["persist_output"])
+                _print_low_memory_stats(backtest)
+            else:
+                backtest.simulate_trading(
+                    persist_output=bool(execution_profile["persist_output"]),
+                )
 
         persisted_counts = _persist_backtest_audit_rows(audit_store, backtest_run_id, backtest)
         audit_store.end_run(
@@ -461,6 +598,37 @@ if __name__ == "__main__":
         action="store_true",
         help="Disable automatic DB market-data collection before loading.",
     )
+    low_memory_group = parser.add_mutually_exclusive_group()
+    low_memory_group.add_argument(
+        "--low-memory",
+        dest="low_memory",
+        action="store_true",
+        help=(
+            "Use low-memory execution profile (record_history=False, record_trades=False, "
+            "track_metrics=True)."
+        ),
+    )
+    low_memory_group.add_argument(
+        "--no-low-memory",
+        dest="low_memory",
+        action="store_false",
+        help="Explicitly disable low-memory profile even if LQ_BACKTEST_LOW_MEMORY is set.",
+    )
+    parser.set_defaults(low_memory=None)
+    persist_group = parser.add_mutually_exclusive_group()
+    persist_group.add_argument(
+        "--persist-output",
+        dest="persist_output",
+        action="store_true",
+        help="Force writing CSV outputs (equity/trades).",
+    )
+    persist_group.add_argument(
+        "--no-persist-output",
+        dest="persist_output",
+        action="store_false",
+        help="Force disabling CSV outputs (equity/trades).",
+    )
+    parser.set_defaults(persist_output=None)
     args = parser.parse_args()
     run(
         data_source=args.data_source,
@@ -469,4 +637,6 @@ if __name__ == "__main__":
         base_timeframe=_normalize_timeframe_or_default(args.base_timeframe, "1s"),
         auto_collect_db=(not bool(args.no_auto_collect_db) and bool(AUTO_COLLECT_DB)),
         run_id=args.run_id,
+        low_memory=args.low_memory,
+        persist_output=args.persist_output,
     )

--- a/run_bot.bat
+++ b/run_bot.bat
@@ -5,11 +5,14 @@ echo [PRODUCTION] Starting Quants Agent in Resilient Mode
 echo ---------------------------------------------------
 
 :start
-echo [INFO] Activating Virtual Environment...
-call .venv\Scripts\activate.bat
+where uv >nul 2>nul
+if %ERRORLEVEL% NEQ 0 (
+  echo [ERROR] uv is required but was not found in PATH.
+  exit /b 1
+)
 
 echo [INFO] Launching Live Trader at %TIME%...
-python run_live.py >> logs\crash.log 2>&1
+uv run python run_live.py >> logs\crash.log 2>&1
 
 echo [WARNING] Bot crashed or stopped! Exit Code: %ERRORLEVEL%
 echo [INFO] Restarting in 5 seconds...

--- a/run_bot.sh
+++ b/run_bot.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Production Startup Script for macOS/Linux
-# Handles virtual environment activation and auto-restart on crash.
+# Uses uv-only runtime and auto-restarts on crash.
 
 echo "---------------------------------------------------"
 echo "[PRODUCTION] Starting Quants Agent in Resilient Mode"
@@ -11,18 +11,13 @@ echo "---------------------------------------------------"
 mkdir -p logs
 
 while true; do
-    echo "[INFO] Activating Virtual Environment..."
-    # Check for venv in standard locations
-    if [ -d ".venv" ]; then
-        source .venv/bin/activate
-    elif [ -d "venv" ]; then
-        source venv/bin/activate
-    else
-        echo "[WARNING] Virtual environment not found! Attempting to run with system python..."
+    if ! command -v uv >/dev/null 2>&1; then
+        echo "[ERROR] uv is required but not found in PATH."
+        exit 1
     fi
 
     echo "[INFO] Launching Live Trader at $(date)..."
-    python3 run_live.py >> logs/crash.log 2>&1
+    uv run python run_live.py >> logs/crash.log 2>&1
     EXIT_CODE=$?
 
     echo "[WARNING] Bot crashed or stopped! Exit Code: $EXIT_CODE"

--- a/scripts/benchmark_backtest_loop.py
+++ b/scripts/benchmark_backtest_loop.py
@@ -1,0 +1,68 @@
+"""Thin wrapper benchmark for the backtest loop used in CI/regression gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = Path(__file__).resolve().parent
+for candidate in (PROJECT_ROOT, SCRIPT_DIR):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+import benchmark_backtest as backtest_benchmark  # noqa: E402
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Benchmark LuminaQuant backtest loop.")
+    parser.add_argument("--config", default="config.yaml", help="Path to YAML config file.")
+    parser.add_argument("--symbols", default="", help="Comma-separated symbols override.")
+    parser.add_argument("--strategy", default=None, help="Strategy class name override.")
+    parser.add_argument("--iters", type=int, default=1, help="Measured iterations.")
+    parser.add_argument("--warmup", type=int, default=0, help="Warmup iterations.")
+    parser.add_argument("--seed", type=int, default=42, help="Deterministic seed.")
+    parser.add_argument(
+        "--record-history",
+        action="store_true",
+        help="Keep full portfolio/trade history during benchmark run.",
+    )
+    parser.add_argument(
+        "--output",
+        default="reports/benchmarks/backtest_loop.json",
+        help="Output JSON path.",
+    )
+    parser.add_argument(
+        "--compare-to",
+        default="",
+        help="Optional path to previous benchmark JSON snapshot for delta report.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    if not backtest_benchmark.STRATEGY_MAP:
+        payload = {
+            "skipped": True,
+            "reason": "strategies package unavailable in this distribution",
+        }
+    else:
+        summary = backtest_benchmark.build_benchmark_summary(args)
+        payload = asdict(summary)
+        previous = backtest_benchmark._load_snapshot(args.compare_to)
+        if previous is not None:
+            payload["comparison"] = backtest_benchmark._build_comparison(summary, previous)
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(json.dumps(payload, indent=2))
+    print(f"Saved benchmark snapshot: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_chunked_backtest.py
+++ b/tests/test_chunked_backtest.py
@@ -80,3 +80,29 @@ def test_run_backtest_loader_uses_parquet_when_detected(tmp_path: Path, monkeypa
     assert data_dict is not None
     assert "BTC/USDT" in data_dict
     assert data_dict["BTC/USDT"].height >= 2
+
+
+def test_resolve_execution_profile_low_memory_defaults(monkeypatch):
+    monkeypatch.delenv("LQ_BACKTEST_LOW_MEMORY", raising=False)
+    monkeypatch.delenv("LQ_BACKTEST_PERSIST_OUTPUT", raising=False)
+
+    profile = run_backtest._resolve_execution_profile(low_memory=True, persist_output=None)
+
+    assert profile["low_memory"] is True
+    assert profile["record_history"] is False
+    assert profile["record_trades"] is False
+    assert profile["track_metrics"] is True
+    assert profile["persist_output"] is False
+
+
+def test_resolve_execution_profile_respects_env_and_override(monkeypatch):
+    monkeypatch.setenv("LQ_BACKTEST_LOW_MEMORY", "1")
+    monkeypatch.setenv("LQ_BACKTEST_PERSIST_OUTPUT", "1")
+
+    profile_env = run_backtest._resolve_execution_profile(low_memory=None, persist_output=None)
+    assert profile_env["low_memory"] is True
+    assert profile_env["persist_output"] is True
+
+    profile_override = run_backtest._resolve_execution_profile(low_memory=None, persist_output=False)
+    assert profile_override["low_memory"] is True
+    assert profile_override["persist_output"] is False

--- a/tests/test_chunked_runner.py
+++ b/tests/test_chunked_runner.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 
 import polars as pl
-from lumina_quant.backtesting.chunked_runner import iter_chunk_windows, run_backtest_chunked
+from lumina_quant.backtesting.chunked_runner import (
+    _capture_backtest_state,
+    iter_chunk_windows,
+    run_backtest_chunked,
+)
 from lumina_quant.strategy import Strategy
 
 
@@ -75,3 +80,36 @@ def test_run_backtest_chunked_calls_loader_per_chunk():
     assert len(calls) == 3
     assert int(backtest.portfolio.trade_count) == 0
     assert float(backtest.portfolio.current_holdings["total"]) > 0.0
+
+
+def test_capture_state_skips_heavy_lists_when_recording_disabled():
+    fake = SimpleNamespace(
+        strategy=SimpleNamespace(get_state=lambda: {"s": 1}),
+        portfolio=SimpleNamespace(
+            get_state=lambda: {"p": 1},
+            all_positions=[("p", 1)],
+            all_holdings=[("h", 1)],
+            trades=[{"id": 1}],
+            trade_count=3,
+            _metric_totals=[1.0, 2.0],
+            _metric_benchmarks=[1.0, 1.1],
+        ),
+        execution_handler=SimpleNamespace(
+            get_state=lambda: {"e": 1},
+            active_orders=[{"id": "o"}],
+            _order_seq=7,
+        ),
+    )
+
+    carry = _capture_backtest_state(
+        fake,
+        record_history=False,
+        track_metrics=True,
+        record_trades=False,
+    )
+
+    assert "all_positions" not in carry
+    assert "all_holdings" not in carry
+    assert "trades" not in carry
+    assert "metric_totals" in carry
+    assert "metric_benchmarks" in carry

--- a/tests/test_dashboard_cleanup_command_contract.py
+++ b/tests/test_dashboard_cleanup_command_contract.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _extract_function_block(source: str, func_name: str) -> str:
+    marker = f"def {func_name}("
+    start = source.find(marker)
+    if start < 0:
+        raise AssertionError(f"{func_name} not found")
+    tail = source[start:]
+    next_def = tail.find("\ndef ")
+    if next_def < 0:
+        return tail
+    return tail[:next_def]
+
+
+def test_dashboard_ghost_cleanup_uses_dsn_flag():
+    dashboard_path = Path(__file__).resolve().parents[1] / "dashboard.py"
+    source = dashboard_path.read_text(encoding="utf-8")
+    block = _extract_function_block(source, "_run_ghost_cleanup_script")
+
+    assert "--dsn" in block
+    assert "--db" not in block

--- a/tests/test_run_backtest_low_memory.py
+++ b/tests/test_run_backtest_low_memory.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+_RUN_BACKTEST_PATH = Path(__file__).resolve().parents[1] / "run_backtest.py"
+_RUN_BACKTEST_SPEC = importlib.util.spec_from_file_location("run_backtest_module", _RUN_BACKTEST_PATH)
+if _RUN_BACKTEST_SPEC is None or _RUN_BACKTEST_SPEC.loader is None:
+    raise RuntimeError(f"Failed to load run_backtest module from {_RUN_BACKTEST_PATH}")
+run_backtest = importlib.util.module_from_spec(_RUN_BACKTEST_SPEC)
+_RUN_BACKTEST_SPEC.loader.exec_module(run_backtest)
+
+
+class _StubAuditStore:
+    def __init__(self, _dsn):
+        self.started = False
+        self.ended = False
+
+    def start_run(self, **_kwargs):
+        self.started = True
+
+    def end_run(self, *_args, **_kwargs):
+        self.ended = True
+
+    def close(self):
+        return None
+
+
+def test_run_low_memory_uses_lightweight_backtest_flow(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class _StubBacktest:
+        def __init__(self, *args, **kwargs):
+            _ = args
+            captured["record_history"] = kwargs.get("record_history")
+            captured["track_metrics"] = kwargs.get("track_metrics")
+            captured["record_trades"] = kwargs.get("record_trades")
+            self.config = SimpleNamespace(PERSIST_OUTPUT=True)
+            self.portfolio = SimpleNamespace(
+                current_holdings={"total": 1234.5},
+                trade_count=0,
+                output_summary_stats_fast=lambda: {
+                    "status": "ok",
+                    "sharpe": 1.0,
+                    "cagr": 0.1,
+                    "max_drawdown": 0.05,
+                },
+                create_equity_curve_dataframe=lambda: None,
+                output_trade_log=lambda _path: None,
+                save_equity_curve=lambda _path: None,
+            )
+
+        def simulate_trading(self, output=True, persist_output=None, verbose=True):
+            captured["simulate_output"] = output
+            captured["simulate_persist_output"] = persist_output
+            captured["simulate_verbose"] = verbose
+            return None
+
+    monkeypatch.setattr(run_backtest, "AuditStore", _StubAuditStore)
+    monkeypatch.setattr(run_backtest, "Backtest", _StubBacktest)
+    monkeypatch.setattr(run_backtest, "_persist_backtest_audit_rows", lambda *_args, **_kwargs: {})
+
+    run_backtest.run(
+        data_source="csv",
+        low_memory=True,
+        persist_output=None,
+        auto_collect_db=False,
+        run_id="test-low-memory",
+    )
+
+    assert captured["record_history"] is False
+    assert captured["track_metrics"] is True
+    assert captured["record_trades"] is False
+    assert captured["simulate_output"] is False
+    assert captured["simulate_persist_output"] is None

--- a/tests/test_run_bot_uv_only.py
+++ b/tests/test_run_bot_uv_only.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_run_bot_uses_uv_runtime():
+    script_path = Path(__file__).resolve().parents[1] / "run_bot.sh"
+    content = script_path.read_text(encoding="utf-8")
+
+    assert "uv run python run_live.py" in content
+    assert "python3 run_live.py" not in content


### PR DESCRIPTION
## Summary
- replace conflicted private-main -> main PR with a conflict-free sanitized sync branch
- carry safe runtime/backtest improvements + uv-only run scripts + 1Y/1s runbook

## Why
Public main intentionally excludes private strategy/indicator source trees. The previous PR conflicted on those deletions.

## Validation
- uv run ruff check .
- uv run python scripts/check_architecture.py
- uv run pytest tests/test_native_backend.py tests/test_optimize_two_stage.py tests/test_message_bus.py tests/test_runtime_cache.py tests/test_system_assembly.py tests/test_ohlcv_loader.py tests/test_execution_protective_orders.py tests/test_live_execution_state_machine.py tests/test_lookahead.py tests/test_chunked_runner.py tests/test_chunked_backtest.py tests/test_dashboard_cleanup_command_contract.py tests/test_run_backtest_low_memory.py tests/test_run_bot_uv_only.py
